### PR TITLE
update minimum cmake to avoid warnings when building as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.11)
+# Require minimum v3.13 so we can set options externally without a warning
+cmake_minimum_required(VERSION 3.13)
 
 # ---------------------------------------------------------------------------------------
 # Start spdlog project


### PR DESCRIPTION
Resolves a cmake policy warning when we set options outside of spdlog (when used as a subdirectory) by increasing the minimum cmake version. Rather than silencing the warning by setting the policy manually, I believe this change better reflects the use of this repo inside the org/engine.